### PR TITLE
Support customizing gitconfig

### DIFF
--- a/roles/git/templates/gitconfig
+++ b/roles/git/templates/gitconfig
@@ -19,3 +19,6 @@
 
 [mergetool "meld"]
     cmd = meld "$LOCAL" "$MERGED" "$REMOTE" --output "$MERGED"
+
+# BEGIN ANSIBLE MANAGED BLOCK
+# END ANSIBLE MANAGED BLOCK


### PR DESCRIPTION
Customize gitconfig, eg. add aliases with a task like below in `custom`
role

```
- blockinfile:
    path: "/home/{{ local_username}}/.gitconfig"
    block: |
        [alias]
            fa = "fetch --all --prune"
            po = "push origin"
            poh = "push --set-upstream origin HEAD"
            ct = "checkout -t"
```